### PR TITLE
Improvment: Cards with uniform size and a hover effect

### DIFF
--- a/src/components/Home/Hero/slider.tsx
+++ b/src/components/Home/Hero/slider.tsx
@@ -12,7 +12,7 @@ const AgentSlider = () => {
     infinite: true,
     autoplaySpeed: 1500,
     speed: 300,
-    slidesToShow: 4,
+    slidesToShow: 3,
     slidesToScroll: 1,
     cssEase: 'ease-in-out',
     responsive: [
@@ -43,7 +43,7 @@ const AgentSlider = () => {
         {AgentFeatures.map((item, index) => (
           <div key={index} className="pr-6">
             <div className="px-5 py-6 bg-dark_grey/80 rounded-xl">
-              <div className="flex items-center gap-5">
+              <div className="flex items-center gap-5 hover:scale-105 transition-transform duration-300">
                 <div className={`${item.background} ${item.padding} rounded-full`}>
                   <Icon icon={item.icon} width={item.width} height={item.height} className="text-primary" />
                 </div>


### PR DESCRIPTION
I have made improvements regarding the home page cards which are now of the same size and have a hover effect.
<img width="1902" height="911" alt="image" src="https://github.com/user-attachments/assets/ad1ec7a2-11e3-4c3c-9c64-0dafc536b4c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Reduced the number of visible slides in the slider from 4 to 3 for a more focused display.
  * Added a smooth scaling hover effect to each feature's icon and text container for improved interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->